### PR TITLE
WordPress 6.9.1 compatibility update

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,9 +4,9 @@ Plugin Name: Edit Usernames
 Description: Change a user's username within the admin screen.
 Author: Miller Media
 Author URI: http://www.millermedia.io
-Version: 1.2.3
+Version: 1.2.4
 Requires PHP: 8.1
-Tested up to: 6.9
+Tested up to: 6.9.1
 License: GPLv2
 Text Domain: edit-usernames
 */

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: MillerMediaNow, mikemm01
 Tags: username, edit, profile, users
 Requires PHP: 8.1
 Requires at least: 3.0
-Tested up to: 6.9
-Stable tag: 1.2.3
+Tested up to: 6.9.1
+Stable tag: 1.2.4
 License: GPLv2
 
 The Edit Usernames plugin allows WordPress admins and WooCommerce managers to edit the users' usernames through the admin dashboard. Simple!
@@ -31,6 +31,9 @@ If you find that a part of this plugin isn't working, let us know what's broken 
 1. Pencil/edit icon in user edit screen
 
 == Changelog ==
+
+= 1.2.4 =
+* Tested up to WordPress 6.9.1
 
 = 1.2.3 =
 * Fixed username field UX - field is now editable by default with clear instructions


### PR DESCRIPTION
Updates plugin to indicate WordPress 6.9.1 compatibility.

**Changes:**
- Bumped plugin version from 1.2.3 to 1.2.4
- Updated 'Tested up to' from 6.9 to 6.9.1
- Added changelog entry for 6.9.1 compatibility

**Testing:**
These are metadata changes only. No code functionality changed.