### PR TITLE
Add POT translation template file

### DIFF
--- a/languages/edit-usernames.pot
+++ b/languages/edit-usernames.pot
@@ -1,0 +1,55 @@
+# Copyright (C) 2026 Edit Usernames
+# This file is distributed under the same license as the Edit Usernames package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Edit Usernames\n"
+"Report-Msgid-Bugs-To: https://github.com/Miller-Media/edit-usernames/issues\n"
+"POT-Creation-Date: 2026-02-16 13:20+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Plugin Name of the plugin
+#: plugin.php
+msgid "Edit Usernames"
+msgstr ""
+
+#. Description of the plugin
+#: plugin.php
+msgid "Change a user's username within the admin screen."
+msgstr ""
+
+#. Author of the plugin
+#: plugin.php
+msgid "Miller Media"
+msgstr ""
+
+#. Author URI of the plugin
+#: plugin.php
+msgid "http://www.millermedia.io"
+msgstr ""
+
+#: inc/edit-usernames.php:35
+msgid "ERROR: Username invalid. Please choose another."
+msgstr ""
+
+#: inc/edit-usernames.php:37
+msgid "ERROR: Username already exists. Please choose another."
+msgstr ""
+
+#: inc/edit-usernames.php:128
+msgid "An error occurred:"
+msgstr ""
+
+#: inc/settings.php:24
+msgid "Edit Usernames Settings"
+msgstr ""
+
+#: inc/settings.php:29
+msgid "Allow admin username editing?"
+msgstr ""
+


### PR DESCRIPTION
Adds `languages/edit-usernames.pot` — the translation template file that enables the WordPress.org translation community to contribute translations via [translate.wordpress.org](https://translate.wordpress.org/).

The POT file contains all translatable strings extracted from the plugin with empty `msgstr` values, serving as the base template for all language translations.