### PR TITLE
Fix Plugin Check (PCP) compliance issues

### DIFF
--- a/inc/edit-usernames.php
+++ b/inc/edit-usernames.php
@@ -125,8 +125,7 @@ class EUN_EditUsernames {
 
                     } else {
                         // Display database error
-                        echo '<div id="message" class="error"><p><strong>' . esc_html__('An error occurred:', 'edit-usernames') . '</strong></p></div>';
-                        var_dump( $wpdb->last_error );
+                        echo '<div id="message" class="error"><p><strong>' . esc_html__('An error occurred:', 'edit-usernames') . '</strong> ' . esc_html( $wpdb->last_error ) . '</p></div>';
                         die();
                     }
                 }

--- a/inc/review-notice.php
+++ b/inc/review-notice.php
@@ -1,4 +1,9 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Review Notice class
  *

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1,13 +1,30 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Access denied.' );
+}
+
 function eun_register_settings() {
     if (false == get_option(EUN_SETTINGS_PREFIX.'options')) {
         add_option( EUN_SETTINGS_PREFIX.'options');
     }
 
-    register_setting( EUN_SETTINGS_PREFIX.'options', EUN_SETTINGS_PREFIX.'options');
+    register_setting( EUN_SETTINGS_PREFIX.'options', EUN_SETTINGS_PREFIX.'options', array(
+        'sanitize_callback' => 'eun_sanitize_options',
+    ) );
 }
 add_action( 'admin_init', 'eun_register_settings' );
+
+function eun_sanitize_options( $input ) {
+    $sanitized = array();
+    if ( isset( $input[ EUN_SETTINGS_PREFIX . 'edit_admin' ] ) ) {
+        $sanitized[ EUN_SETTINGS_PREFIX . 'edit_admin' ] = sanitize_text_field( $input[ EUN_SETTINGS_PREFIX . 'edit_admin' ] );
+    }
+    if ( isset( $input[ EUN_SETTINGS_PREFIX . 'delete_data_on_uninstall' ] ) ) {
+        $sanitized[ EUN_SETTINGS_PREFIX . 'delete_data_on_uninstall' ] = sanitize_text_field( $input[ EUN_SETTINGS_PREFIX . 'delete_data_on_uninstall' ] );
+    }
+    return $sanitized;
+}
 
 function eun_register_options_page() {
     add_options_page('General Settings', EUN_PLUGIN_NAME, 'manage_options', 'eun_settings', 'eun_settings_options_page');
@@ -26,15 +43,15 @@ function eun_settings_options_page()
   <?php settings_fields( EUN_SETTINGS_PREFIX.'options' ); ?>
   <table>
   <tr>
-  <th scope="row"><label for="<?php echo $option_array_name.'['.EUN_SETTINGS_PREFIX.'edit_admin]'; ?>"><?php esc_html_e('Allow admin username editing?', 'edit-usernames'); ?></label></th>
+  <th scope="row"><label for="<?php echo esc_attr( $option_array_name . '[' . EUN_SETTINGS_PREFIX . 'edit_admin]' ); ?>"><?php esc_html_e('Allow admin username editing?', 'edit-usernames'); ?></label></th>
   <td>
-      <input type="checkbox" id="<?php echo esc_attr(EUN_SETTINGS_PREFIX.'edit_admin'); ?>" name="<?php echo $option_array_name.'['.EUN_SETTINGS_PREFIX.'edit_admin]'?>" <?php if(is_array($options) && array_key_exists(EUN_SETTINGS_PREFIX.'edit_admin', $options) && $options[EUN_SETTINGS_PREFIX.'edit_admin']=='on'){echo 'checked=checked';} ?>.'/
+      <input type="checkbox" id="<?php echo esc_attr(EUN_SETTINGS_PREFIX.'edit_admin'); ?>" name="<?php echo esc_attr( $option_array_name . '[' . EUN_SETTINGS_PREFIX . 'edit_admin]' ); ?>" <?php if(is_array($options) && array_key_exists(EUN_SETTINGS_PREFIX.'edit_admin', $options) && $options[EUN_SETTINGS_PREFIX.'edit_admin']=='on'){echo 'checked=checked';} ?>/>
   </td>
   </tr>
   <tr>
-  <th scope="row"><label for="<?php echo $option_array_name.'['.EUN_SETTINGS_PREFIX.'delete_data_on_uninstall]'; ?>"><?php esc_html_e('Remove all plugin data when deleted', 'edit-usernames'); ?></label></th>
+  <th scope="row"><label for="<?php echo esc_attr( $option_array_name . '[' . EUN_SETTINGS_PREFIX . 'delete_data_on_uninstall]' ); ?>"><?php esc_html_e('Remove all plugin data when deleted', 'edit-usernames'); ?></label></th>
   <td>
-      <input type="checkbox" id="<?php echo esc_attr(EUN_SETTINGS_PREFIX.'delete_data_on_uninstall'); ?>" name="<?php echo $option_array_name.'['.EUN_SETTINGS_PREFIX.'delete_data_on_uninstall]'?>" <?php if(is_array($options) && array_key_exists(EUN_SETTINGS_PREFIX.'delete_data_on_uninstall', $options) && $options[EUN_SETTINGS_PREFIX.'delete_data_on_uninstall']=='on'){echo 'checked=checked';} ?>/>
+      <input type="checkbox" id="<?php echo esc_attr(EUN_SETTINGS_PREFIX.'delete_data_on_uninstall'); ?>" name="<?php echo esc_attr( $option_array_name . '[' . EUN_SETTINGS_PREFIX . 'delete_data_on_uninstall]' ); ?>" <?php if(is_array($options) && array_key_exists(EUN_SETTINGS_PREFIX.'delete_data_on_uninstall', $options) && $options[EUN_SETTINGS_PREFIX.'delete_data_on_uninstall']=='on'){echo 'checked=checked';} ?>/>
       <p class="description"><?php esc_html_e('Check this box if you want all plugin settings and data to be removed when the plugin is deleted.', 'edit-usernames'); ?></p>
   </td>
   </tr>

--- a/plugin.php
+++ b/plugin.php
@@ -4,9 +4,9 @@ Plugin Name: Edit Usernames
 Description: Change a user's username within the admin screen.
 Author: Miller Media
 Author URI: https://mattmiller.ai
-Version:           1.3.1
+Version:           1.3.2
 Requires PHP: 8.1
-Tested up to: 6.9.1
+Tested up to: 6.9
 License: GPL-2.0-or-later
 Text Domain: edit-usernames
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -15,10 +15,6 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-add_action('plugins_loaded', function() {
-    load_plugin_textdomain('edit-usernames', false, dirname(plugin_basename(__FILE__)) . '/languages');
-});
 
 if ( is_admin() ){
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: MillerMediaNow, mikemm01
 Tags: username, edit, profile, users
 Requires PHP: 8.1
 Requires at least: 3.0
-Tested up to: 6.9.1
-Stable tag: 1.3.1
+Tested up to: 6.9
+Stable tag: 1.3.2
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -108,6 +108,14 @@ The plugin is available in 30 languages with more being added regularly. We are 
 1. Pencil/edit icon in user edit screen
 
 == Changelog ==
+
+= 1.3.2 =
+* Added ABSPATH checks to inc/settings.php and inc/review-notice.php
+* Added sanitization callback to register_setting()
+* Fixed unescaped attribute outputs in settings page
+* Removed var_dump() debug call
+* Removed deprecated load_plugin_textdomain() call
+* Updated "Tested up to" to 6.9
 
 = 1.3.1 =
 * Added GPL license declaration to plugin header


### PR DESCRIPTION
## Changes in v1.3.2

### Security & Standards
- **ABSPATH checks** added to `inc/settings.php` and `inc/review-notice.php`
- **Sanitization callback** added to `register_setting()` with `eun_sanitize_options()`
- **Unescaped attributes fixed**: label `for=` attributes now use `esc_attr()`
- **Removed `var_dump()`**: Replaced debug call with `esc_html($wpdb->last_error)` output

### Cleanup
- Removed deprecated `load_plugin_textdomain()` call
- Removed `languages/.gitkeep`

### Version
- Bumped to **1.3.2**
- Updated "Tested up to" to **6.9**